### PR TITLE
disable DEBUG_CHECK

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,10 +31,10 @@
     "include_dirs": ["<!(node -e \"require('nan')\")"],
     "defines": [
       "USE_NUM_OPENSSL=1",
-      "USE_FIELD_INV_BUILTIN=1"
+      "USE_FIELD_INV_BUILTIN=1",
+      "NDEBUG=1"
     ],
     'conditions': [
-      
       [
         'target_arch=="ia32"', {
           'defines': [

--- a/index.js
+++ b/index.js
@@ -145,22 +145,14 @@ exports.verify = function(pubKey, msg, sig, cb){
  * @method recoverCompact
  * @param {Buffer} msg the message assumed to be signed
  * @param {Buffer} sig the signature as 64 byte buffer
- * @param {Integer} recid the recovery id (as returned by ecdsa_sign_compact). should be [0,3]
+ * @param {Integer} recid the recovery id (as returned by ecdsa_sign_compact)
  * @param {Boolean} compressed whether to recover a compressed or uncompressed pubkey
  * @param {Function} [cb]
- * @return {Buffer|null} the pubkey, a 33 or 65 byte buffer, or null if invalid input
+ * @return {Buffer} the pubkey, a 33 or 65 byte buffer
  */
 exports.recoverCompact = function(msg, sig, recid, compressed, cb){
 
   compressed = compressed ? 1 : 0;
-
-  if (recid < 0 || recid > 3) {
-    if (!cb) {
-      return null;
-    } else {
-      return cb('failed recid >= 0 && recid <= 3');
-    }
-  }
 
   if(!cb){
     return secpNode.recoverCompact(msg, sig, compressed, recid);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secp256k1",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "main": "index.js",
   "scripts": {

--- a/src/src/secp256k1.c
+++ b/src/src/secp256k1.c
@@ -38,7 +38,7 @@ int secp256k1_ecdsa_verify(const unsigned char *msg, int msglen, const unsigned 
     DEBUG_CHECK(pubkey != NULL);
 
     int ret = -3;
-    secp256k1_num_t m;
+    secp256k1_num_t m; 
     secp256k1_num_init(&m);
     secp256k1_ecdsa_sig_t s;
     secp256k1_ecdsa_sig_init(&s);
@@ -143,10 +143,10 @@ int secp256k1_ecdsa_recover_compact(const unsigned char *msg, int msglen, const 
     DEBUG_CHECK(sig64 != NULL);
     DEBUG_CHECK(pubkey != NULL);
     DEBUG_CHECK(pubkeylen != NULL);
-    //DEBUG_CHECK(recid >= 0 && recid <= 3);
+    DEBUG_CHECK(recid >= 0 && recid <= 3);
 
     int ret = 0;
-    secp256k1_num_t m;
+    secp256k1_num_t m; 
     secp256k1_num_init(&m);
     secp256k1_ecdsa_sig_t sig;
     secp256k1_ecdsa_sig_init(&sig);

--- a/src/src/secp256k1.c
+++ b/src/src/secp256k1.c
@@ -38,7 +38,7 @@ int secp256k1_ecdsa_verify(const unsigned char *msg, int msglen, const unsigned 
     DEBUG_CHECK(pubkey != NULL);
 
     int ret = -3;
-    secp256k1_num_t m; 
+    secp256k1_num_t m;
     secp256k1_num_init(&m);
     secp256k1_ecdsa_sig_t s;
     secp256k1_ecdsa_sig_init(&s);
@@ -143,10 +143,10 @@ int secp256k1_ecdsa_recover_compact(const unsigned char *msg, int msglen, const 
     DEBUG_CHECK(sig64 != NULL);
     DEBUG_CHECK(pubkey != NULL);
     DEBUG_CHECK(pubkeylen != NULL);
-    DEBUG_CHECK(recid >= 0 && recid <= 3);
+    //DEBUG_CHECK(recid >= 0 && recid <= 3);
 
     int ret = 0;
-    secp256k1_num_t m; 
+    secp256k1_num_t m;
     secp256k1_num_init(&m);
     secp256k1_ecdsa_sig_t sig;
     secp256k1_ecdsa_sig_init(&sig);

--- a/test/index.js
+++ b/test/index.js
@@ -102,4 +102,19 @@ describe('it should handle basic ecdsa ops', function () {
       done();
     });
   });
+
+  it('should not crash when recoverId is out of bounds - sync', function() {
+    var sig = ecdsaNative.recoverCompact(msg, compactSig.signature, -27, true);
+    assert.notStrictEqual(sig.toString('hex'), null);
+    assert.strictEqual(sig.length, 33);
+  });
+
+  it('should not crash when recoverId is out of bounds - async', function(done) {
+    ecdsaNative.recoverCompact(msg, compactSig.signature, -27, true, function(err, sig) {
+      assert.strictEqual(err, 1);
+      assert.notStrictEqual(sig.toString('hex'), null);
+      assert.strictEqual(sig.length, 33);
+      done();
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -102,17 +102,4 @@ describe('it should handle basic ecdsa ops', function () {
       done();
     });
   });
-
-  it('should not crash when recoverId is out of bounds - sync', function() {
-    var sig = ecdsaNative.recoverCompact(msg, compactSig.signature, -27, true);
-    assert.strictEqual(sig, null);
-  });
-
-  it('should not crash when recoverId is out of bounds - async', function(done) {
-    ecdsaNative.recoverCompact(msg, compactSig.signature, -27, true, function(err, sig) {
-      assert.strictEqual(err, 'failed recid >= 0 && recid <= 3');
-      assert.strictEqual(sig, undefined);
-      done();
-    });
-  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -103,10 +103,16 @@ describe('it should handle basic ecdsa ops', function () {
     });
   });
 
-  it('should not crash when recoverId is out of bounds - sync', function() {
+  it('should not crash when recoverId is out of bounds negative - sync', function() {
     var sig = ecdsaNative.recoverCompact(msg, compactSig.signature, -27, true);
     assert.notStrictEqual(sig.toString('hex'), null);
     assert.strictEqual(sig.length, 33);
+  });
+
+  it('should not crash when recoverId is out of bounds positive - sync', function() {
+    var sig = ecdsaNative.recoverCompact(msg, compactSig.signature, 2342342327, true);
+    assert.notStrictEqual(sig.toString('hex'), null);
+    assert.strictEqual(sig, false);
   });
 
   it('should not crash when recoverId is out of bounds - async', function(done) {


### PR DESCRIPTION
revert back to 0.0.8 and build without DEBUG_CHECK

the recid can be out of bounds, eg CallEcrecover2 test: https://github.com/ethereum/tests/blob/develop/StateTests/stPreCompiledContracts.json
