### PR TITLE
Updated to the latest version of secp256k1 submodule 

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,7 +38,7 @@
       "./secp256k1-src/src/util.h"
     ],
     "cflags": [
-      "--std=c1x",
+      "-DHAVE___INT128",
       "-Wall",
       "-Wno-maybe-uninitialized",
       "-Wno-uninitialized",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secp256k1",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "main": "index.js",
   "scripts": {

--- a/secp256k1.cc
+++ b/secp256k1.cc
@@ -12,14 +12,17 @@ class SignWorker : public NanAsyncWorker {
   SignWorker(NanCallback *callback, const unsigned char *msg, const unsigned char *pk)
     : NanAsyncWorker(callback), msg(msg), pk(pk), sig_len(72) {}
   // Destructor
-  ~SignWorker() {}
+  ~SignWorker() {
+      secp256k1_context_destroy(this->ctx);
+  }
 
   // Executed inside the worker-thread.
   // It is not safe to access V8, or V8 data structures
   // here, so everything we need for input and output
   // should go on `this`.
   void Execute () {
-    this->result = secp256k1_ecdsa_sign(this->msg, this->sig , &this->sig_len, this->pk, NULL, NULL);
+    this->ctx    = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    this->result = secp256k1_ecdsa_sign(this->ctx, this->msg, this->sig , &this->sig_len, this->pk, NULL, NULL);
   }
 
   // Executed when the async work is complete
@@ -35,6 +38,7 @@ class SignWorker : public NanAsyncWorker {
   }
 
  protected:
+  secp256k1_context_t * ctx;
   const unsigned char * msg;
   const unsigned char * pk;
   int sig_len;
@@ -48,7 +52,8 @@ class CompactSignWorker : public SignWorker {
     : SignWorker(callback, msg, pk){}
 
   void Execute () {
-    this->result = secp256k1_ecdsa_sign_compact(this->msg, this->sig , this->pk, NULL, NULL,  &this->sig_len);
+    this->ctx    = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    this->result = secp256k1_ecdsa_sign_compact(this->ctx, this->msg, this->sig , this->pk, NULL, NULL,  &this->sig_len);
   }
 
   void HandleOKCallback () {
@@ -68,7 +73,9 @@ class RecoverWorker : public NanAsyncWorker {
   RecoverWorker(NanCallback *callback, const unsigned char *msg, const unsigned char *sig, int compressed, int rec_id)
     : NanAsyncWorker(callback), msg(msg), sig(sig), compressed(compressed), rec_id(rec_id) {}
   // Destructor
-  ~RecoverWorker() {}
+  ~RecoverWorker() {
+      secp256k1_context_destroy(this->ctx);
+  }
 
   void Execute () {
     if(this->compressed == 1){
@@ -77,7 +84,8 @@ class RecoverWorker : public NanAsyncWorker {
       this->pubkey = new unsigned char[65]; 
     }
 
-    this->result = secp256k1_ecdsa_recover_compact(this->msg, this->sig, this->pubkey, &this->pubkey_len, this->compressed, this->rec_id);
+    this->ctx    = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    this->result = secp256k1_ecdsa_recover_compact(this->ctx, this->msg, this->sig, this->pubkey, &this->pubkey_len, this->compressed, this->rec_id);
   }
 
   void HandleOKCallback () {
@@ -90,6 +98,7 @@ class RecoverWorker : public NanAsyncWorker {
   }
 
  protected:
+  secp256k1_context_t * ctx;
   const unsigned char * msg;
   const unsigned char * sig; 
   int compressed;
@@ -105,10 +114,13 @@ class VerifyWorker : public NanAsyncWorker {
   VerifyWorker(NanCallback *callback, const unsigned char *msg, const unsigned char *sig, int sig_len, const unsigned char *pub_key, int pub_key_len)
     : NanAsyncWorker(callback), msg(msg), sig(sig), sig_len(sig_len), pub_key(pub_key), pub_key_len(pub_key_len) {}
   // Destructor
-  ~VerifyWorker() {}
+  ~VerifyWorker() {
+      secp256k1_context_destroy(this->ctx);
+  }
 
   void Execute () {
-    this->result = secp256k1_ecdsa_verify(this->msg, this->sig, this->sig_len,  this->pub_key, this->pub_key_len);
+    this->ctx    = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    this->result = secp256k1_ecdsa_verify(this->ctx, this->msg, this->sig, this->sig_len,  this->pub_key, this->pub_key_len);
   }
 
   void HandleOKCallback () {
@@ -120,6 +132,7 @@ class VerifyWorker : public NanAsyncWorker {
   }
 
  protected:
+  secp256k1_context_t * ctx;
   int result;
   const unsigned char * msg;
   const unsigned char * sig;
@@ -142,7 +155,9 @@ NAN_METHOD(Verify){
   const unsigned char *sig_data = (unsigned char *) node::Buffer::Data(sig_buf);
   int sig_len = node::Buffer::Length(args[2]);
 
-  int result = secp256k1_ecdsa_verify(msg_data, sig_data, sig_len, pub_data, pub_len ); 
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int result = secp256k1_ecdsa_verify(ctx, msg_data, sig_data, sig_len, pub_data, pub_len ); 
+  secp256k1_context_destroy(ctx);
 
   NanReturnValue(NanNew<Number>(result));
 }
@@ -193,7 +208,9 @@ NAN_METHOD(Sign){
     return NanThrowError("messgae cannot be null"); 
   }
 
-  int result = secp256k1_ecdsa_sign(msg_data, sig , &sig_len, pk_data, NULL, NULL);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+  int result = secp256k1_ecdsa_sign(ctx, msg_data, sig , &sig_len, pk_data, NULL, NULL);
+  secp256k1_context_destroy(ctx);
 
   if(result == 1){
     NanReturnValue(NanNewBufferHandle((char *)sig, sig_len));
@@ -256,7 +273,9 @@ NAN_METHOD(Sign_Compact){
   int rec_id;
 
   //TODO: change the nonce
-  int valid_nonce = secp256k1_ecdsa_sign_compact(msg_data, sig, seckey_data, NULL, NULL, &rec_id );
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+  int valid_nonce = secp256k1_ecdsa_sign_compact(ctx, msg_data, sig, seckey_data, NULL, NULL, &rec_id );
+  secp256k1_context_destroy(ctx);
 
   Local<Array> array = NanNew<Array>(3);
   array->Set(0, NanNew<Integer>(valid_nonce));
@@ -322,7 +341,9 @@ NAN_METHOD(Recover_Compact){
 
   int pubKeyLen;
 
-  int result = secp256k1_ecdsa_recover_compact(msg, sig, pubKey, &pubKeyLen, int_compressed, int_rec_id);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int result = secp256k1_ecdsa_recover_compact(ctx, msg, sig, pubKey, &pubKeyLen, int_compressed, int_rec_id);
+  secp256k1_context_destroy(ctx);
   if(result == 1){
     NanReturnValue(NanNewBufferHandle((char *)pubKey, pubKeyLen));
   }else{
@@ -376,7 +397,9 @@ NAN_METHOD(Seckey_Verify){
   NanScope();
 
   const unsigned char *data = (const unsigned char*) node::Buffer::Data(args[0]);
-  int result =  secp256k1_ec_seckey_verify(data); 
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int result =  secp256k1_ec_seckey_verify(ctx, data); 
+  secp256k1_context_destroy(ctx);
   NanReturnValue(NanNew<Number>(result)); 
 }
 
@@ -388,7 +411,9 @@ NAN_METHOD(Pubkey_Verify){
   const unsigned char *pub_key = (unsigned char *) node::Buffer::Data(pub_buf);
   int pub_key_len = node::Buffer::Length(args[0]);
 
-  int result = secp256k1_ec_pubkey_verify(pub_key, pub_key_len);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int result = secp256k1_ec_pubkey_verify(ctx, pub_key, pub_key_len);
+  secp256k1_context_destroy(ctx);
 
   NanReturnValue(NanNew<Number>(result)); 
 }
@@ -415,7 +440,9 @@ NAN_METHOD(Pubkey_Create){
     pubKey = new unsigned char[65]; 
   }
 
-  int results = secp256k1_ec_pubkey_create(pubKey,&pubKeyLen, pk_data, compact );
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+  int results = secp256k1_ec_pubkey_create(ctx, pubKey,&pubKeyLen, pk_data, compact );
+  secp256k1_context_destroy(ctx);
   if(results == 0){
     return NanThrowError("secret was invalid, try again.");
   }else{
@@ -432,7 +459,9 @@ NAN_METHOD(Pubkey_Decompress){
 
   int pk_len = node::Buffer::Length(args[0]);
 
-  int results = secp256k1_ec_pubkey_decompress(pk_data, &pk_len);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+  int results = secp256k1_ec_pubkey_decompress(ctx, pk_data, pk_data, &pk_len);
+  secp256k1_context_destroy(ctx);
 
   if(results == 0){
     return NanThrowError("invalid public key");
@@ -452,7 +481,9 @@ NAN_METHOD(Privkey_Import){
   int pk_len = node::Buffer::Length(args[0]);
 
   unsigned char sec_key[32];
-  int results = secp256k1_ec_privkey_import(sec_key, pk_data, pk_len);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+  int results = secp256k1_ec_privkey_import(ctx, sec_key, pk_data, pk_len);
+  secp256k1_context_destroy(ctx);
 
   if(results == 0){
     return NanThrowError("invalid private key");
@@ -473,7 +504,9 @@ NAN_METHOD(Privkey_Export){
 
   unsigned char *privKey;
   int pk_len;
-  int results = secp256k1_ec_privkey_export(sk_data, privKey, &pk_len, compressed);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+  int results = secp256k1_ec_privkey_export(ctx, sk_data, privKey, &pk_len, compressed);
+  secp256k1_context_destroy(ctx);
   if(results == 0){
     return NanThrowError("invalid private key");
   }else{
@@ -491,7 +524,9 @@ NAN_METHOD(Privkey_Tweak_Add){
   Handle<Object> tweak_buf = args[1].As<Object>();
   const unsigned char *tweak= (unsigned char *) node::Buffer::Data(tweak_buf);
 
-  int results = secp256k1_ec_privkey_tweak_add(sk, tweak);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int results = secp256k1_ec_privkey_tweak_add(ctx, sk, tweak);
+  secp256k1_context_destroy(ctx);
   if(results == 0){
     return NanThrowError("invalid key");
   }else{
@@ -509,7 +544,9 @@ NAN_METHOD(Privkey_Tweak_Mul){
   Handle<Object> tweak_buf = args[1].As<Object>();
   const unsigned char *tweak= (unsigned char *) node::Buffer::Data(tweak_buf);
 
-  int results = secp256k1_ec_privkey_tweak_mul(sk, tweak);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int results = secp256k1_ec_privkey_tweak_mul(ctx, sk, tweak);
+  secp256k1_context_destroy(ctx);
   if(results == 0){
     return NanThrowError("invalid key");
   }else{
@@ -528,7 +565,9 @@ NAN_METHOD(Pubkey_Tweak_Add){
   Handle<Object> tweak_buf = args[1].As<Object>();
   const unsigned char *tweak= (unsigned char *) node::Buffer::Data(tweak_buf);
 
-  int results = secp256k1_ec_pubkey_tweak_add(pk, pk_len, tweak);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int results = secp256k1_ec_pubkey_tweak_add(ctx, pk, pk_len, tweak);
+  secp256k1_context_destroy(ctx);
   if(results == 0){
     return NanThrowError("invalid key");
   }else{
@@ -547,7 +586,9 @@ NAN_METHOD(Pubkey_Tweak_Mul){
   Handle<Object> tweak_buf = args[1].As<Object>();
   const unsigned char *tweak= (unsigned char *) node::Buffer::Data(tweak_buf);
 
-  int results = secp256k1_ec_pubkey_tweak_mul(pk, pk_len, tweak);
+  secp256k1_context_t * ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+  int results = secp256k1_ec_pubkey_tweak_mul(ctx, pk, pk_len, tweak);
+  secp256k1_context_destroy(ctx);
   if(results == 0){
     return NanThrowError("invalid key");
   }else{
@@ -557,7 +598,6 @@ NAN_METHOD(Pubkey_Tweak_Mul){
 
 void Init(Handle<Object> exports) {
 
-  secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY);
   exports->Set(NanNew("seckeyVerify"), NanNew<FunctionTemplate>(Seckey_Verify)->GetFunction());
   exports->Set(NanNew("sign"), NanNew<FunctionTemplate>(Sign)->GetFunction());
   exports->Set(NanNew("signAsync"), NanNew<FunctionTemplate>(Sign_Async)->GetFunction());


### PR DESCRIPTION
Hacked the glue code till it worked. I do not claim any knowledge of what I am doing and if I am doing it right, was just for fun of it.

I also had problems with uint128_t which should work but since we are not running configure in the submodule and not picking-up the cc flags, I had to hard code "-DHAVE___INT128" in bindings.gyp, which will probably break on some platforms.
