### PR TITLE
Add support for node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
 language: node_js
 node_js:
+  - 0.10
   - 0.11
   - 0.12
   - 4

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # secp256k1-node
 
-[![NPM Package](https://img.shields.io/npm/v/secp256k1-node.svg?style=flat-square)](https://www.npmjs.org/package/secp256k1-node)
+[![NPM Package](https://img.shields.io/npm/v/secp256k1.svg?style=flat-square)](https://www.npmjs.org/package/secp256k1)
 [![Build Status](https://img.shields.io/travis/wanderer/secp256k1-node.svg?branch=master&style=flat-square)](https://travis-ci.org/wanderer/secp256k1-node)
 [![Coverage Status](https://img.shields.io/coveralls/wanderer/secp256k1-node.svg?style=flat-square)](https://coveralls.io/r/wanderer/secp256k1-node)
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
 This module provides native bindings to ecdsa [secp256k1](https://github.com/bitcoin/secp256k1) functions.
-This library is experimental, so use at your own risk. Works on node version 0.11 or greater.
+This library is experimental, so use at your own risk. Works on node version 0.10 or greater.
 
 # Installation
 

--- a/lib/elliptic/index.js
+++ b/lib/elliptic/index.js
@@ -50,13 +50,13 @@ asyncFunctions.forEach(function (obj) {
         setImmediate(callback, null, value)
       }
 
-      return Promise.resolve(value)
+      return exports.Promise.resolve(value)
     } catch (err) {
       if (callback !== undefined) {
         setImmediate(callback, err)
       }
 
-      return Promise.reject(err)
+      return exports.Promise.reject(err)
     }
   }
 })

--- a/src/publickey.cc
+++ b/src/publickey.cc
@@ -38,7 +38,7 @@ NAN_METHOD(publicKeyConvert) {
   size_t inputlen = node::Buffer::Length(pubkey_buffer);
 
   unsigned int flags = SECP256K1_EC_COMPRESSED;
-  v8::Local<v8::Value> compressed = info[1].As<v8::Value>();
+  v8::Local<v8::Value> compressed = info[1];
   if (!compressed->IsUndefined()) {
     CHECK_TYPE_BOOLEAN(compressed, COMPRESSED_TYPE_INVALID);
     if (!compressed->BooleanValue()) {

--- a/src/secretkey.cc
+++ b/src/secretkey.cc
@@ -34,7 +34,7 @@ NAN_METHOD(secretKeyExport) {
   const unsigned char* seckey = (const unsigned char*) node::Buffer::Data(seckey_buffer);
 
   int compressed = 1;
-  v8::Local<v8::Value> compressed_value = info[1].As<v8::Value>();
+  v8::Local<v8::Value> compressed_value = info[1];
   if (!compressed_value->IsUndefined()) {
     CHECK_TYPE_BOOLEAN(compressed_value, COMPRESSED_TYPE_INVALID);
     if (!compressed_value->BooleanValue()) {


### PR DESCRIPTION
This PR adds support for node 0.10 since some LTS distros still use it, and used addon wrapper `nan` supports it.

Actually everything is fine, just fix for few quirks and bugs.
