### PR TITLE
Changes to build on Mac OS X

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -80,7 +80,13 @@
        'OS=="mac"', {
           "libraries": [
             "-L/usr/local/lib"
-          ]
+          ],
+          "xcode_settings": {
+            "MACOSX_DEPLOYMENT_TARGET": '10.7',
+            "OTHER_CPLUSPLUSFLAGS": [
+              '-stdlib=libc++'
+            ]
+          }
       }],
       [
         "OS=='win'", {


### PR DESCRIPTION
I was able to build the package on Mac OS X 10.11.1 with Xcode 7.1.1 with these changes. This should resolve issue #48 "Error with node-gyp rebuild in El Capitan"
