### PR TITLE
fix for recovery id validation on 32bytes +

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secp256k1",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "keywords": [
     "secp256k1",

--- a/src/recover.cc
+++ b/src/recover.cc
@@ -24,7 +24,7 @@ class RecoverWorker : public AsyncWorker {
 
         CHECK_TYPE_NUMBER_ASYNC(recid_number, ECDSA_SIGNATURE_RECOVERY_ID_TYPE_INVALID);
         CHECK_NUMBER_IN_INTERVAL_ASYNC(recid_number, -1, 4, ECDSA_SIGNATURE_RECOVERY_ID_VALUE_INVALID);
-        recid = recid_number->Int32Value();
+        recid = recid_number->IntegerValue();
     }
 
     void Execute () {
@@ -91,7 +91,7 @@ NAN_METHOD(recoverSync) {
   v8::Local<v8::Object> recid_number = info[2].As<v8::Object>();
   CHECK_TYPE_NUMBER(recid_number, ECDSA_SIGNATURE_RECOVERY_ID_TYPE_INVALID);
   CHECK_NUMBER_IN_INTERVAL(recid_number, -1, 4, ECDSA_SIGNATURE_RECOVERY_ID_VALUE_INVALID);
-  int recid = recid_number->Int32Value();
+  int recid = recid_number->IntegerValue();
 
   secp256k1_ecdsa_recoverable_signature sig;
   if (secp256k1_ecdsa_recoverable_signature_parse_compact(secp256k1ctx, &sig, input, recid) == 0) {

--- a/src/util.h
+++ b/src/util.h
@@ -96,13 +96,13 @@
 }
 
 #define CHECK_NUMBER_IN_INTERVAL(number, x, y, msg) {                          \
-  if (number->Int32Value() <= x || number->Int32Value() >= y) {                \
+  if (number->IntegerValue() <= x || number->IntegerValue() >= y) {            \
     return Nan::ThrowRangeError(msg);                                          \
   }                                                                            \
 }
 
 #define CHECK_NUMBER_IN_INTERVAL_ASYNC(number, x, y, msg) {                    \
-  if (number->Int32Value() <= x || number->Int32Value() >= y) {                \
+  if (number->IntegerValue() <= x || number->IntegerValue() >= y) {            \
     SetError(AsyncWorker::RangeError, msg);                                    \
     return;                                                                    \
   }                                                                            \

--- a/test/recover.js
+++ b/test/recover.js
@@ -50,6 +50,11 @@ module.exports = function (secp256k1, opts) {
       return expect(promise).to.be.rejectedWith(RangeError, /recovery/)
     })
 
+    it('recovery is invalid (equal 32 bytes+)', function () {
+      var promise = secp256k1.recover(util.getMessage(), util.getSignature(), 57779999999999999999999999999999999999999999999)
+      return expect(promise).to.be.rejectedWith(RangeError, /recovery/)
+    })
+
     it('signature is invalid (r equal N)', function () {
       var signature = Buffer.concat([
         util.ecparams.n.toBuffer(32),


### PR DESCRIPTION
if the recovery id  is greater than 32 bytes then the method `number->Int32Value` returns zero.
