### PR TITLE
Use BN.isZero() in the elliptic wrapper

### DIFF
--- a/lib/elliptic/publickey.js
+++ b/lib/elliptic/publickey.js
@@ -106,7 +106,7 @@ exports.publicKeyTweakMul = function (publicKey, tweak) {
   }
 
   tweak = new BN(tweak)
-  if (util.isOverflow(tweak) || util.isZero(tweak)) {
+  if (util.isOverflow(tweak) || tweak.isZero()) {
     throw new Error(messages.EC_PUBKEY_TWEAK_MUL_FAIL)
   }
 

--- a/lib/elliptic/secretkey.js
+++ b/lib/elliptic/secretkey.js
@@ -165,7 +165,7 @@ exports.secretKeyTweakAdd = function (secretKey, tweak) {
   }
 
   bn = util.bnReduce(bn.iadd(new BN(secretKey)))
-  if (util.isZero(bn)) {
+  if (bn.isZero()) {
     throw new Error(messages.EC_PRIVKEY_TWEAK_ADD_FAIL)
   }
 
@@ -187,7 +187,7 @@ exports.secretKeyTweakMul = function (secretKey, tweak) {
   asserts.checkBufferLength(tweak, 32, messages.TWEAK_LENGTH_INVALID)
 
   var bn = new BN(tweak)
-  if (util.isOverflow(bn) || util.isZero(bn)) {
+  if (util.isOverflow(bn) || bn.isZero()) {
     throw new Error(messages.EC_PRIVKEY_TWEAK_MUL_FAIL)
   }
 

--- a/lib/elliptic/util.js
+++ b/lib/elliptic/util.js
@@ -2,15 +2,13 @@ var BN = require('bn.js')
 
 var ec = require('./ec')
 
-var ZERO = new BN(0)
-
 /**
  * @param {Buffer} secretKey
  * @return {boolean}
  */
 exports.isValidSecretKey = function (secretKey) {
   var bn = new BN(secretKey)
-  return !exports.isOverflow(bn) && !exports.isZero(bn)
+  return !exports.isOverflow(bn) && !bn.isZero()
 }
 
 /**
@@ -63,14 +61,6 @@ exports.isValidSignature = function (signature) {
  */
 exports.isOverflow = function (bn) {
   return bn.cmp(ec.curve.n) >= 0
-}
-
-/**
- * @param {BN} bn
- * @return {boolean}
- */
-exports.isZero = function (bn) {
-  return bn.cmp(ZERO) === 0
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "bindings": "^1.2.1",
     "bluebird": "^3.0.2",
-    "bn.js": "^4.2.0",
+    "bn.js": "^4.5.0",
     "elliptic": "^6.0.2",
     "nan": "^2.0.9",
     "object-assign": "^4.0.1"


### PR DESCRIPTION
Just replace utils.isZero() with BN.isZero() which is available since v4.5.0.

Perhaps it also makes sense to use BN v4.6.2 as it has bug fixes and speed improvements.
