### PR TITLE
default node export

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -1,3 +1,7 @@
 'use strict'
 
-module.exports = require('bindings')('secp256k1')
+try {
+  module.exports = require('bindings')('secp256k1')
+} catch (err) {
+  module.exports = require('./elliptic')
+}

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "bindings.js",
     "elliptic.js",
     "js.js",
-    "package.json",
-    "LICENSE",
-    "README.md",
     "utils/has_lib.sh"
   ],
   "main": "./bindings.js",


### PR DESCRIPTION
Related issue: #71 
Right now fallback is `elliptic`.
