### PR TITLE
Embedded implementation instead elliptic

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -3,5 +3,5 @@
 try {
   module.exports = require('bindings')('secp256k1')
 } catch (err) {
-  module.exports = require('./elliptic')
+  module.exports = require('./js')
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
   },
   "gypfile": true,
   "browser": {
-    "./bindings.js": "./elliptic.js"
+    "./bindings.js": "./js.js"
   }
 }


### PR DESCRIPTION
Would be happy hear any thoughts about this, especially if somebody against this.
Should note that `elliptic` will be still available (`require('secp256k1/elliptic')`).
