### PR TITLE
Expose libsecp256k1's sha256 function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "secp256k1-src"]
 	path = src/secp256k1-src
-	url = https://github.com/bitcoin/secp256k1
+	url = https://github.com/bitcoin-core/secp256k1

--- a/binding.gyp
+++ b/binding.gyp
@@ -28,6 +28,7 @@
       "./src/signature.cc",
       "./src/ecdsa.cc",
       "./src/ecdh.cc",
+      "./src/hash.cc",
       "./src/secp256k1-src/src/secp256k1.c",
       "./src/secp256k1-src/contrib/lax_der_privatekey_parsing.c"
     ],

--- a/lib/elliptic/index.js
+++ b/lib/elliptic/index.js
@@ -245,3 +245,11 @@ exports.ecdhUnsafe = function (publicKey, privateKey, compressed) {
 
   return new Buffer(pair.pub.mul(scalar).encode(true, compressed))
 }
+
+exports.sha256 = function (data) {
+  return createHash('sha256').update(data).digest()
+}
+
+exports.dsha256 = function (data) {
+  return exports.sha256(exports.sha256(data));
+}

--- a/lib/elliptic/index.js
+++ b/lib/elliptic/index.js
@@ -251,5 +251,5 @@ exports.sha256 = function (data) {
 }
 
 exports.dsha256 = function (data) {
-  return exports.sha256(exports.sha256(data));
+  return exports.sha256(exports.sha256(data))
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -321,7 +321,7 @@ module.exports = function (secp256k1) {
     dsha256: function (data) {
       assert.isBuffer(data, 'Buffer expected.')
       return secp256k1.dsha256(data)
-    },
+    }
 
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -311,6 +311,17 @@ module.exports = function (secp256k1) {
       compressed = initCompressedValue(compressed, true)
 
       return secp256k1.ecdhUnsafe(publicKey, privateKey, compressed)
-    }
+    },
+
+    sha256: function (data) {
+      assert.isBuffer(data, 'Buffer expected.')
+      return secp256k1.sha256(data)
+    },
+
+    dsha256: function (data) {
+      assert.isBuffer(data, 'Buffer expected.')
+      return secp256k1.dsha256(data)
+    },
+
   }
 }

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -7,6 +7,7 @@
 #include "signature.h"
 #include "ecdsa.h"
 #include "ecdh.h"
+#include "hash.h"
 
 secp256k1_context* secp256k1ctx;
 
@@ -42,6 +43,10 @@ NAN_MODULE_INIT(Init) {
   // ecdh
   Nan::Export(target, "ecdh", ecdh);
   Nan::Export(target, "ecdhUnsafe", ecdhUnsafe);
+
+  // hash
+  Nan::Export(target, "sha256", sha256);
+  Nan::Export(target, "dsha256", dsha256);
 }
 
 NODE_MODULE(secp256k1, Init)

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -1,0 +1,55 @@
+#include <node.h>
+#include <nan.h>
+#include <secp256k1.h>
+#include <util.h>
+#include <field_impl.h>
+#include <scalar_impl.h>
+#include <group_impl.h>
+#include <ecmult_const_impl.h>
+#include <ecmult_gen_impl.h>
+
+#include "messages.h"
+#include "util.h"
+
+NAN_METHOD(sha256) {
+  Nan::HandleScope scope;
+
+  v8::Local<v8::Object> buf = info[0].As<v8::Object>();
+  CHECK_TYPE_BUFFER(buf, "Buffer expected.");
+  const unsigned char* data = (unsigned char*) node::Buffer::Data(buf);
+  size_t len = node::Buffer::Length(buf);
+
+  secp256k1_sha256_t sha;
+  unsigned char output[32];
+
+  secp256k1_sha256_initialize(&sha);
+  secp256k1_sha256_write(&sha, data, len);
+  secp256k1_sha256_finalize(&sha, &output[0]);
+
+  info.GetReturnValue().Set(COPY_BUFFER(&output[0], 32));
+}
+
+NAN_METHOD(dsha256) {
+  Nan::HandleScope scope;
+
+  v8::Local<v8::Object> buf = info[0].As<v8::Object>();
+  CHECK_TYPE_BUFFER(buf, "Buffer expected.");
+  const unsigned char* data = (unsigned char*) node::Buffer::Data(buf);
+  size_t len = node::Buffer::Length(buf);
+
+  secp256k1_sha256_t sha;
+  unsigned char output[32];
+
+  secp256k1_sha256_initialize(&sha);
+  secp256k1_sha256_write(&sha, data, len);
+  secp256k1_sha256_finalize(&sha, &output[0]);
+
+  secp256k1_sha256_t sha2;
+  unsigned char output2[32];
+
+  secp256k1_sha256_initialize(&sha2);
+  secp256k1_sha256_write(&sha2, output, 32);
+  secp256k1_sha256_finalize(&sha2, &output2[0]);
+
+  info.GetReturnValue().Set(COPY_BUFFER(&output2[0], 32));
+}

--- a/src/hash.cc
+++ b/src/hash.cc
@@ -44,12 +44,9 @@ NAN_METHOD(dsha256) {
   secp256k1_sha256_write(&sha, data, len);
   secp256k1_sha256_finalize(&sha, &output[0]);
 
-  secp256k1_sha256_t sha2;
-  unsigned char output2[32];
+  secp256k1_sha256_initialize(&sha);
+  secp256k1_sha256_write(&sha, output, 32);
+  secp256k1_sha256_finalize(&sha, &output[0]);
 
-  secp256k1_sha256_initialize(&sha2);
-  secp256k1_sha256_write(&sha2, output, 32);
-  secp256k1_sha256_finalize(&sha2, &output2[0]);
-
-  info.GetReturnValue().Set(COPY_BUFFER(&output2[0], 32));
+  info.GetReturnValue().Set(COPY_BUFFER(&output[0], 32));
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,0 +1,10 @@
+#ifndef _SECP256K1_NODE_HASH_
+# define _SECP256K1_NODE_HASH_
+
+#include <node.h>
+#include <nan.h>
+
+NAN_METHOD(sha256);
+NAN_METHOD(dsha256);
+
+#endif


### PR DESCRIPTION
Quick and dirty. This would be really nice to have considering that it is roughly 2-4x faster than openssl (the double sha is especially fast since it doesn't require extra instantiation of js objects, unlike node's crypto module). I think it's reasonable to not expose an updateable object since the constant crossover between js->c++ adds overhead, and I can't think of _that_ much in bitcoin that would require or benefit from it. Having it as a single function is just simple and fast.

Also updated the git submodule to point at the bitcoin-core org.
