### PR TITLE
has_lib: buffer the output of ls to avoid broken pipes.

### DIFF
--- a/utils/has_lib.sh
+++ b/utils/has_lib.sh
@@ -9,7 +9,7 @@ has_lib() {
 
   # Try just checking common library locations
   for dir in /lib /usr/lib /usr/local/lib /opt/local/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu; do
-    test -d $dir && ls $dir | grep -E $regex && return 0
+    test -d $dir && echo "$(ls $dir)" | grep -E $regex && return 0
   done
 
   return 1


### PR DESCRIPTION
This was causing a build failure on my machine:

```
ls: write error: Broken pipe
ls: write error: Broken pipe
gyp: Call to 'utils/has_lib.sh gmpxx && utils/has_lib.sh gmp' returned exit status 0 while in binding.gyp. while trying to load binding.gyp
```

If the output of `ls $dir` is large, grep will exit before it has read the entire output of ls, resulting in a broken pipe.
