### PR TITLE
fix node modules version for electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "create-hash": "^1.2.0",
     "drbg.js": "^1.0.1",
     "elliptic": "^6.4.1",
-    "nan": "^2.13.2",
+    "nan": "^2.14.0",
     "safe-buffer": "^5.1.2"
   },
   "devDependencies": {

--- a/src/ecdsa.cc
+++ b/src/ecdsa.cc
@@ -19,7 +19,7 @@ int nonce_function_custom(unsigned char *nonce32, const unsigned char *msg32, co
   };
 
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
-#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
   v8::Local<v8::Value> result = noncefn_callback->Call(isolate->GetCurrentContext(), isolate->GetCurrentContext()->Global(), 5, argv).ToLocalChecked();
 #else
   v8::Local<v8::Value> result = noncefn_callback->Call(isolate->GetCurrentContext()->Global(), 5, argv);
@@ -52,7 +52,7 @@ NAN_METHOD(sign) {
   if (!options->IsUndefined()) {
     CHECK_TYPE_OBJECT(options, OPTIONS_TYPE_INVALID);
 
-#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
     v8::Local<v8::Value> data_value = options->Get(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("data").ToLocalChecked()).ToLocalChecked();
 #else
     v8::Local<v8::Value> data_value = options->Get(Nan::New<v8::String>("data").ToLocalChecked());
@@ -63,7 +63,7 @@ NAN_METHOD(sign) {
       data = (void*) node::Buffer::Data(data_value);
     }
 
-#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
     noncefn_callback = v8::Local<v8::Function>::Cast(options->Get(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("noncefn").ToLocalChecked()).ToLocalChecked());
 #else
     noncefn_callback = v8::Local<v8::Function>::Cast(options->Get(Nan::New<v8::String>("noncefn").ToLocalChecked()));
@@ -84,7 +84,7 @@ NAN_METHOD(sign) {
   secp256k1_ecdsa_recoverable_signature_serialize_compact(secp256k1ctx, &output[0], &recid, &sig);
 
   v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("signature").ToLocalChecked(), COPY_BUFFER(&output[0], 64));
   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("recovery").ToLocalChecked(), Nan::New<v8::Number>(recid));
 #else

--- a/src/publickey.cc
+++ b/src/publickey.cc
@@ -143,7 +143,7 @@ NAN_METHOD(publicKeyCombine) {
   std::unique_ptr<secp256k1_pubkey[]> public_keys(new secp256k1_pubkey[input_buffers->Length()]);
   std::unique_ptr<secp256k1_pubkey*[]> ins(new secp256k1_pubkey*[input_buffers->Length()]);
   for (unsigned int i = 0; i < input_buffers->Length(); ++i) {
-#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
     v8::Local<v8::Object> public_key_buffer = v8::Local<v8::Object>::Cast(input_buffers->Get(info.GetIsolate()->GetCurrentContext(), i).ToLocalChecked());
 #else
     v8::Local<v8::Object> public_key_buffer = v8::Local<v8::Object>::Cast(input_buffers->Get(i));

--- a/src/util.h
+++ b/src/util.h
@@ -8,7 +8,7 @@
 
 #define COPY_BUFFER(data, datalen) Nan::CopyBuffer((const char*) data, (uint32_t) datalen).ToLocalChecked()
 
-#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
 #define UPDATE_COMPRESSED_VALUE(compressed, value, v_true, v_false) {          \
   if (!value->IsUndefined()) {                                                 \
     CHECK_TYPE_BOOLEAN(value, COMPRESSED_TYPE_INVALID);                        \


### PR DESCRIPTION
Was introduced in #143, issue #147 
When added node@12 support, nan did not had `NODE_12_0_MODULE_VERSION`, equal to 72. `NODE_11_0_MODULE_VERSION` equal to 67. Electron can have versions between 67 and 72, so condition:
```
NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION
```
broken building for Electron.