### PR TITLE
Update elliptic due to signature malleability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secp256k1",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "keywords": [
     "ec",
@@ -32,7 +32,7 @@
     "install": "node-gyp-build || exit 0"
   },
   "dependencies": {
-    "elliptic": "^6.5.2",
+    "elliptic": "^6.5.3",
     "node-addon-api": "^2.0.0",
     "node-gyp-build": "^4.2.0"
   },


### PR DESCRIPTION
GitHub published CVE-2020-13822 citing a signature malleability in the
package `elliptic`. This bumps `elliptic` to 6.5.3 in which they
released a fix for that package.

Ref: https://github.com/advisories/GHSA-vh7m-p724-62c2