### PR TITLE
Support Buffer in node environment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,10 @@ function assert(cond, msg) {
 
 function isUint8Array(name, value, length) {
   const canAcceptBuffer = isNode && value && value.constructor.name === "Buffer"
+  assert(
+    value instanceof Uint8Array || canAcceptBuffer,
+    `Expected ${name} to be an Uint8Array`
+  )
 
   if (length !== undefined) {
     if (Array.isArray(length)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,16 +14,17 @@ const errors = {
   ECDH: 'Scalar was invalid (zero or overflow)'
 }
 
-function assert (cond, msg) {
+const isNode =
+  typeof process !== "undefined" &&
+  process.versions != null &&
+  process.versions.node != null
+
+function assert(cond, msg) {
   if (!cond) throw new Error(msg)
 }
 
-function isUint8Array (name, value, length) {
-  const canAcceptBuffer = typeof document === 'undefined' && value && value.constructor.name === "Buffer"
-  assert(
-    value instanceof Uint8Array || canAcceptBuffer,
-    `Expected ${name} to be an Uint8Array`
-  )
+function isUint8Array(name, value, length) {
+  const canAcceptBuffer = isNode && value && value.constructor.name === "Buffer"
 
   if (length !== undefined) {
     if (Array.isArray(length)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,11 @@ function assert (cond, msg) {
 }
 
 function isUint8Array (name, value, length) {
-  assert(value instanceof Uint8Array, `Expected ${name} to be an Uint8Array`)
+  const valueIsBuffer = !process.browser && value && value.constructor.name === "Buffer"
+  assert(
+    value instanceof Uint8Array || valueIsBuffer,
+    `Expected ${name} to be an Uint8Array`
+  )
 
   if (length !== undefined) {
     if (Array.isArray(length)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,9 +19,9 @@ function assert (cond, msg) {
 }
 
 function isUint8Array (name, value, length) {
-  const valueIsBuffer = !process.browser && value && value.constructor.name === "Buffer"
+  const canAcceptBuffer = typeof document === 'undefined' && value && value.constructor.name === "Buffer"
   assert(
-    value instanceof Uint8Array || valueIsBuffer,
+    value instanceof Uint8Array || canAcceptBuffer,
     `Expected ${name} to be an Uint8Array`
   )
 


### PR DESCRIPTION
~Fixes #175~ 

If I understand correctly, Buffer is a subclass of Uint8Array that extends it, thus it should be ok to use Buffer. 

[API reference](https://github.com/cryptocoinjs/secp256k1-node/blob/master/API.md) mentions that the browser's Buffer is lacking behind, this is why I included `isNode` flag