### PR TITLE
Resolve GitHub CVE advisory by updating to latest elliptic

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "install": "node-gyp-build || exit 0"
   },
   "dependencies": {
-    "elliptic": "^6.5.2",
+    "elliptic": "^6.5.4",
     "node-addon-api": "^2.0.0",
     "node-gyp-build": "^4.2.0"
   },


### PR DESCRIPTION
In versions of elliptic prior to 6.5.4, there is no check to confirm that the public key point passed into the derive function actually exists on the secp256k1 curve. This results in the potential for the private key used in this implementation to be revealed after a number of ECDH operations are performed.

See https://github.com/advisories/GHSA-r9p9-mrjm-926w