### PR TITLE
docs: fix example of unrelated public/private pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ function getPrivateKey () {
 
 // generate private and public keys
 const privKey = getPrivateKey()
-const pubKey = secp256k1.publicKeyCreate(getPrivateKey())
+const pubKey = secp256k1.publicKeyCreate(privKey)
 
 // compressed public key from X and Y
 function hashfn (x, y) {


### PR DESCRIPTION
The example shows generating a public key from an unrelated private key.

This fixes it to show the intended use of generating a related keypair.