### PR TITLE
fix: segfaults when used with worker_threads

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "elliptic": "^6.5.4",
-    "node-addon-api": "^2.0.0",
+    "node-addon-api": "^3.2.1",
     "node-gyp-build": "^4.2.0"
   },
   "devDependencies": {

--- a/src/secp256k1.cc
+++ b/src/secp256k1.cc
@@ -26,8 +26,7 @@
   } while (0)
 
 // Secp256k1
-Napi::FunctionReference Secp256k1Addon::constructor;
-unsigned int Secp256k1Addon::secp256k1_context_flags =
+const unsigned int Secp256k1Addon::secp256k1_context_flags =
     SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY;
 
 Napi::Value Secp256k1Addon::Init(Napi::Env env) {
@@ -66,8 +65,9 @@ Napi::Value Secp256k1Addon::Init(Napi::Env env) {
           InstanceMethod("ecdh", &Secp256k1Addon::ECDH),
       });
 
-  constructor = Napi::Persistent(func);
-  constructor.SuppressDestruct();
+  Napi::FunctionReference* constructor = new Napi::FunctionReference();
+  *constructor = Napi::Persistent(func);
+  env.SetInstanceData<Napi::FunctionReference>(constructor);
 
   return func;
 }

--- a/src/secp256k1.h
+++ b/src/secp256k1.h
@@ -28,8 +28,7 @@ class Secp256k1Addon : public Napi::ObjectWrap<Secp256k1Addon> {
   };
 
  private:
-  static Napi::FunctionReference constructor;
-  static unsigned int secp256k1_context_flags;
+  static const unsigned int secp256k1_context_flags;
   const secp256k1_context* ctx_;
   ECDSASignData ecdsa_sign_data;
   ECDHData ecdh_data;


### PR DESCRIPTION
This PR makes the lib more robust when used in combination with `worker_threads`.
We've observed that the usage of the global `constructor` field is not thread-safe and may lead to segfaults.

Fixes issue: #172 

Minimal segfaulting example without this change:

```javascript
const wt = require('worker_threads');
const foo = require('secp256k1');

if(wt.isMainThread) {
  for(let i = 0; i < 100; i++) {
    new wt.Worker(__filename);
  }
}
```