### PR TITLE
feat: noble secp256k1 support

### DIFF
--- a/bitcoinerlab.js
+++ b/bitcoinerlab.js
@@ -1,0 +1,2 @@
+BigInt(1)
+module.exports = require('./lib')(require('./lib/bitcoinerlab'))

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 try {
   module.exports = require('./bindings')
 } catch (err) {
-  module.exports = require('./elliptic')
+  try {
+    module.exports = require('./bitcoinerlab')
+  } catch (e) {
+    module.exports = require('./elliptic')
+  }
 }

--- a/lib/bitcoinerlab.js
+++ b/lib/bitcoinerlab.js
@@ -1,0 +1,139 @@
+const secp256k1 = require('@bitcoinerlab/secp256k1')
+
+const errors = {
+  EXPECTED_PRIVATE: 'Expected Private',
+  EXPECTED_POINT: 'Expected Point',
+  EXPECTED_SIGNATURE: 'Expected Signature'
+}
+
+// Pre-load elliptic as a backup
+const elliptic = require('./elliptic')
+
+function isCompressedPublicKey (array) {
+  return array.length === 33
+}
+
+module.exports = {
+  contextRandomize: function () {
+    // Historically served to randomize the context in constant time, RNG is sufficiently randomized internally.
+    return 0
+  },
+  privateKeyVerify: function (privateKey) {
+    return secp256k1.isPrivate(privateKey) ? 0 : 1
+  },
+  privateKeyNegate: function (privateKey) {
+    try {
+      const res = secp256k1.privateNegate(privateKey)
+      if (!res) return 1
+      privateKey.set(res)
+    } catch (e) {
+      elliptic.privateKeyNegate(privateKey)
+    }
+    return 0
+  },
+  privateKeyTweakAdd: function (privateKey, tweak) {
+    try {
+      const res = secp256k1.privateAdd(privateKey, tweak)
+      if (!res) return 1
+      privateKey.set(res)
+    } catch (e) {
+      return 1
+    }
+    return 0
+  },
+  privateKeyTweakMul: function (privateKey, tweak) {
+    return elliptic.privateKeyTweakMul(privateKey, tweak)
+  },
+  publicKeyVerify: function (publicKey) {
+    return secp256k1.isPoint(publicKey) ? 0 : 1
+  },
+  publicKeyCreate: function (output, seckey) {
+    try {
+      const res = secp256k1.pointFromScalar(seckey, isCompressedPublicKey(output))
+      if (!res) return 2
+      output.set(res)
+      return 0
+    } catch (e) {
+      return 1
+    }
+  },
+  publicKeyConvert: function (output, pubkey) {
+    try {
+      output.set(secp256k1.pointCompress(pubkey, isCompressedPublicKey(output)))
+      return 0
+    } catch (e) {
+      if (e.message === errors.EXPECTED_POINT) return 1
+      return 2
+    }
+  },
+  publicKeyNegate: function (output, pubkey) {
+    return elliptic.publicKeyNegate(output, pubkey)
+  },
+  publicKeyCombine: function (output, pubkeys) {
+    return elliptic.publicKeyCombine(output, pubkeys)
+  },
+  publicKeyTweakAdd: function (output, pubkey, tweak) {
+    try {
+      const res = secp256k1.pointAddScalar(pubkey, tweak, isCompressedPublicKey(output))
+      if (!res) return 2
+      output.set(res)
+      return 0
+    } catch (e) {
+      if (e.message === errors.EXPECTED_POINT) return 1
+      return 2
+    }
+  },
+  publicKeyTweakMul: function (output, pubkey, tweak) {
+    try {
+      const res = secp256k1.pointMultiply(pubkey, tweak, isCompressedPublicKey(output))
+      if (!res) return 2
+      output.set(res)
+      return 0
+    } catch (e) {
+      if (e.message === errors.EXPECTED_POINT) return 1
+      return 2
+    }
+  },
+  signatureNormalize: function (sig) {
+    return elliptic.signatureNormalize(sig)
+  },
+  signatureExport: function (obj, sig) {
+    return elliptic.signatureExport(obj, sig)
+  },
+  signatureImport: function (output, sig) {
+    return elliptic.signatureImport(output, sig)
+  },
+  ecdsaSign: function (obj, msg32, seckey, data, noncefn) {
+    if (noncefn) {
+      return elliptic.ecdsaSign(obj, msg32, seckey, data, noncefn)
+    }
+    try {
+      obj.signature.set(secp256k1.sign(msg32, seckey, data))
+      Object.defineProperty(obj, 'recid', {
+        get: function () {
+          const obj = { signature: this.signature, recid: null }
+          elliptic.ecdsaSign(obj, msg32, seckey, data, noncefn)
+          return obj.recid
+        }
+      })
+      return 0
+    } catch (e) {
+      if (e.message === errors.EXPECTED_PRIVATE) return 1
+      return 2
+    }
+  },
+  ecdsaVerify: function (signature, message, publicKey) {
+    try {
+      return secp256k1.verify(message, publicKey, signature) ? 0 : 3
+    } catch (e) {
+      if (e.message === errors.EXPECTED_SIGNATURE) return 1
+      return 2
+    }
+  },
+  ecdsaRecover: function (output, sig, recid, msg32) {
+    return elliptic.ecdsaRecover(output, sig, recid, msg32)
+  },
+  ecdh: function (output, pubkey, seckey, data, hashfn, xbuf, ybuf) {
+    return elliptic.ecdh(output, pubkey, seckey, data, hashfn, xbuf, ybuf)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "install": "node-gyp-build || exit 0"
   },
   "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.0.5",
     "elliptic": "^6.5.4",
     "node-addon-api": "^5.0.0",
     "node-gyp-build": "^4.2.0"

--- a/test/index.js
+++ b/test/index.js
@@ -18,3 +18,4 @@ function testAPI (secp256k1, description) {
 
 if (!process.browser) testAPI(require('../bindings'), 'secp256k1 bindings')
 testAPI(require('../elliptic'), 'elliptic')
+testAPI(require('../bitcoinerlab'), 'bitcoinerlab')


### PR DESCRIPTION
Adds `@bitcoinerlab/secp256k1` support for faster crypto operations on React Native's Hermes JS engine.
`@bitcoinerlab/secp256k1` itself is based upon audited `@noble/secp256k1`.
`@noble/secp256k1` main benefit is that it's based on JS BigInt instead of `bn.js`

Preserves API falls back to legacy methods for certain methods
