### PR TITLE
Update elliptic to 6.5.7 (CVE-2024-42461)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Get minimal Node.js version from package.json (Windows)
         id: node-version-win
         if: runner.os == 'Windows'
-        run: echo "::set-output name=version::$(node -p 'require(\"./package.json\").engines.node.match(/(\d+)\..*$/)[1]')"
+        run: echo "::set-output name=version::$(node -p 'require("./package.json").engines.node.match(/(\d+)\..*$/)[1]')"
 
       - name: Use Node.js ${{ steps.node-version-win.outputs.version }} (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,27 +22,14 @@ jobs:
         with:
           submodules: true
 
-      - name: Get minimal Node.js version from package.json (Linux & macOS)
-        id: node-version-nix
-        if: runner.os != 'Windows'
+      - name: Get minimal Node.js version from package.json
+        id: node-version
         run: echo "::set-output name=version::$(node -p 'require("./package.json").engines.node.match(/(\d+)\..*$/)[1]')"
 
-      - name: Use Node.js ${{ steps.node-version-nix.outputs.version }} (Linux & macOS)
-        if: runner.os != 'Windows'
+      - name: Use Node.js ${{ steps.node-version.outputs.version }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ steps.node-version-nix.outputs.version }}
-
-      - name: Get minimal Node.js version from package.json (Windows)
-        id: node-version-win
-        if: runner.os == 'Windows'
-        run: echo "::set-output name=version::$(node -p 'require("./package.json").engines.node.match(/(\d+)\..*$/)[1]')"
-
-      - name: Use Node.js ${{ steps.node-version-win.outputs.version }} (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ steps.node-version-win.outputs.version }}
+          node-version: ${{ steps.node-version.outputs.version }}
 
       - name: Install dependencies
         run: npm install --ignore-scripts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,11 @@ jobs:
           name: addon-Windows
 
       - name: Move addons to one folder
-        run: mkdir prebuilds && mv ./addon-*/* ./prebuilds/
+        run: |
+          mkdir prebuilds
+          mv darwin-arm64 prebuilds
+          mv linux-x64 prebuilds
+          mv win32-x64 prebuilds
 
       - name: Build package
         run: make package

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=version::$(node -p 'require("./package.json").engines.node.match(/(\d+)\..*$/)[1]')"
 
       - name: Use Node.js ${{ steps.node-version.outputs.version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.node-version.outputs.version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           node-version: ${{ steps.node-version-win.outputs.version }}
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: Build addon
         if: runner.os != 'Linux'
@@ -75,7 +75,7 @@ jobs:
           submodules: true
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: Download macOS addon
         uses: actions/download-artifact@v1
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install dependencies
-        run: yarn install --ignore-scripts
+        run: npm install --ignore-scripts
 
       - name: Run lint command
         run: make lint-js

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           - windows-2019
     steps:
       - name: Fetch code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -59,7 +59,7 @@ jobs:
         run: make test-tap
 
       - name: Upload prebuilds
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: addon-${{ runner.os }}
           path: prebuilds
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -78,17 +78,17 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Download macOS addon
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: addon-macOS
 
       - name: Download Linux addon
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: addon-Linux
 
       - name: Download Windows addon
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: addon-Windows
 
@@ -103,7 +103,7 @@ jobs:
         run: echo "::set-output name=version::$(node -p 'require("./package.json").version')"
 
       - name: Upload package
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: secp256k1-${{ steps.pkg-version.outputs.version }}.tgz
@@ -113,11 +113,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: cache
         with:
           path: clang
@@ -137,9 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch code
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm install --ignore-scripts

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ prebuildify-cross = ./node_modules/.bin/prebuildify-cross
 # hack, otherwise GitHub Actions for Windows:
 #  '.' is not recognized as an internal or external command, operable program or batch file.
 build-addon:
-	$(prebuildify) --target node@14.0.0 --napi --strip && node -p "process.platform"
+	$(prebuildify) --target node@18.0.0 --napi --strip && node -p "process.platform"
 
 build-addon-linux:
-	$(prebuildify-cross) -i centos7-devtoolset7 -i alpine --target node@14.0.0 --napi --strip
+	$(prebuildify-cross) -i centos7-devtoolset7 -i alpine --target node@18.0.0 --napi --strip
 
 
 nyc = ./node_modules/.bin/nyc

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "install": "node-gyp-build || exit 0"
   },
   "dependencies": {
-    "elliptic": "^6.5.4",
+    "elliptic": "^6.5.7",
     "node-addon-api": "^5.0.0",
     "node-gyp-build": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "devDependencies": {
     "node-gyp": "^5.0.7",
     "nyc": "^15.0.0",
-    "prebuildify": "^5.0.0",
-    "prebuildify-cross": "^4.0.2",
+    "prebuildify": "^6.0.1",
+    "prebuildify-cross": "^5.1.0",
     "standard": "^14.3.1",
     "tap-dot": "^2.0.0",
     "tape": "^4.10.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node-gyp": "^5.0.7",
     "nyc": "^15.0.0",
     "prebuildify": "^6.0.1",
-    "prebuildify-cross": "^5.1.0",
+    "prebuildify-cross": "github:fanatid/prebuildify-cross#9f7af67698f06e07d42304d9813a6f19aee5812c",
     "standard": "^14.3.1",
     "tap-dot": "^2.0.0",
     "tape": "^4.10.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "yargs": "^15.0.2"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-gyp-build": "^4.2.0"
   },
   "devDependencies": {
-    "node-gyp": "^5.0.7",
+    "node-gyp": "=10.1.0",
     "nyc": "^15.0.0",
     "prebuildify": "^6.0.1",
     "prebuildify-cross": "github:fanatid/prebuildify-cross#9f7af67698f06e07d42304d9813a6f19aee5812c",


### PR DESCRIPTION
In the Elliptic package 6.5.6 for Node.js, ECDSA signature malleability occurs because BER-encoded signatures are allowed.
See https://nvd.nist.gov/vuln/detail/CVE-2024-42461
https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-7577918